### PR TITLE
add default option and nuxt support

### DIFF
--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -1,0 +1,19 @@
+const { resolve } = require('path')
+
+module.exports = function nuxtVueWaitModule (moduleOptions) {
+
+ const defaults = {
+    alias: 'cookies'
+  }
+  const options = Object.assign({}, defaults, moduleOptions)
+
+  this.addPlugin({
+    src: resolve(__dirname, './plugin.template.js'),
+    fileName: 'vue-cookies.js',
+    options
+  })
+
+}
+
+// required by nuxt
+module.exports.meta = require('../package.json')

--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -2,10 +2,7 @@ const { resolve } = require('path')
 
 module.exports = function nuxtVueWaitModule (moduleOptions) {
 
- const defaults = {
-    alias: 'cookies'
-  }
-  const options = Object.assign({}, defaults, moduleOptions)
+  const options = Object.assign({}, this.options.cookies, moduleOptions)
 
   this.addPlugin({
     src: resolve(__dirname, './plugin.template.js'),

--- a/nuxt/index.js
+++ b/nuxt/index.js
@@ -7,7 +7,7 @@ module.exports = function nuxtVueWaitModule (moduleOptions) {
   this.addPlugin({
     src: resolve(__dirname, './plugin.template.js'),
     fileName: 'vue-cookies.js',
-    options
+    options: options
   })
 
 }

--- a/nuxt/plugin.template.js
+++ b/nuxt/plugin.template.js
@@ -5,7 +5,7 @@ export default (obj, inject) => {
     
   // inject options from module
   const pluginOptions = [<%= serialize(options) %>][0] || {}
-  const property = pluginOptions.property || '$cookies'
+  const property = pluginOptions.property || 'cookies'
 
   Vue.use(VueCookies, pluginOptions)
 

--- a/nuxt/plugin.template.js
+++ b/nuxt/plugin.template.js
@@ -1,0 +1,13 @@
+import Vue from 'vue'
+import VueCookies from 'vue-cookies'
+
+export default (obj, inject) => {  
+    
+  // inject options from module
+  const pluginOptions = [<%= serialize(options) %>][0] || {}
+  const property = pluginOptions.property || '$cookies'
+
+  Vue.use(VueCookies, pluginOptions)
+
+  inject(property, Vue.$cookies)
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.7.0",
   "description": "A simple Vue.js plugin for handling browser cookies",
   "main": "vue-cookies.js",
+  "files": [
+    "nuxt"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/vue-cookies.js
+++ b/vue-cookies.js
@@ -18,9 +18,10 @@
 
     var VueCookies = {
         // install of Vue
-        install: function(Vue) {
+        install: function(Vue,options) {
             Vue.prototype.$cookies = this
             Vue.$cookies = this
+            if(defaultConfig) defaultConfig = options
         },
         config : function(expireTimes,path,domain,secure,sameSite) {
             defaultConfig.expires = expireTimes ? expireTimes : '1d';

--- a/vue-cookies.js
+++ b/vue-cookies.js
@@ -18,9 +18,10 @@
 
     var VueCookies = {
         // install of Vue
-        install: function(Vue,options) {
-            Vue.prototype.$cookies = this
-            Vue.$cookies = this
+        install: function(Vue,options) {            
+            const property = options.property || 'cookies'
+            Vue.prototype['$'+property] = this
+            Vue['$'+property] = this
             if(options) defaultConfig = options
         },
         config : function(expireTimes,path,domain,secure,sameSite) {

--- a/vue-cookies.js
+++ b/vue-cookies.js
@@ -21,7 +21,7 @@
         install: function(Vue,options) {
             Vue.prototype.$cookies = this
             Vue.$cookies = this
-            if(defaultConfig) defaultConfig = options
+            if(options) defaultConfig = options
         },
         config : function(expireTimes,path,domain,secure,sameSite) {
             defaultConfig.expires = expireTimes ? expireTimes : '1d';


### PR DESCRIPTION
**1. Can set default options on vue.use**
```
Vue.use(VueCookies, {
    expires: '1d',
    path: '; path=/',
    domain: '',
    secure: '',
    sameSite: ''
}}
```

**2. Add implement support with nuxt module**
# nuxt.config.js
```
    modules: [
        ['vue-cookies/nuxt', { property: 'cookies' , ... { options }  }],
    ],

or

    modules: [
        'vue-cookies/nuxt',
    ],

  cookies: {
    expires: '1d',
    path: '; path=/',
    domain: '',
    secure: '',
    sameSite: ''
  },
```
