### PR TITLE
let user determine whether encode cookie's value or not

### DIFF
--- a/sample/welcome.html
+++ b/sample/welcome.html
@@ -21,7 +21,7 @@
   </div>
 </body>
 <script>
-
+  Vue.$cookies.encodeValue(false);
   new Vue({
     el:'#v-main',
     data: function() {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,13 +7,18 @@ export interface VueCookies {
   /**
    * Set global config
    */
-  config(expireTimes: string | number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: string): void;
+  config(expireTimes: string | number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: string, encodeValue?: boolean): void;
+
+  /**
+   * Set encodeValue
+   */
+  encodeValue(encodeValue?: boolean): void;
 
   /**
    * Set a cookie
    */
   set(keyName: string, value: any, expireTimes?: string | number | Date,
-    path?: string, domain?: string, secure?: boolean, sameSite?: string): this;
+    path?: string, domain?: string, secure?: boolean, sameSite?: string, encode?: boolean): this;
 
   /**
    * Get a cookie

--- a/vue-cookies.js
+++ b/vue-cookies.js
@@ -13,7 +13,8 @@
     path: '; path=/',
     domain: '',
     secure: '',
-    sameSite: '; SameSite=Lax'
+    sameSite: '; SameSite=Lax',
+    encodeValue: true
   };
 
   var VueCookies = {
@@ -22,15 +23,20 @@
       Vue.prototype.$cookies = this;
       Vue.$cookies = this;
     },
-    config: function (expireTimes, path, domain, secure, sameSite) {
+    config: function (expireTimes, path, domain, secure, sameSite, encodeValue) {
       defaultConfig.expires = expireTimes ? expireTimes : '1d';
       defaultConfig.path = path ? '; path=' + path : '; path=/';
       defaultConfig.domain = domain ? '; domain=' + domain : '';
       defaultConfig.secure = secure ? '; Secure' : '';
       defaultConfig.sameSite = sameSite ? '; SameSite=' + sameSite : '; SameSite=Lax';
+      defaultConfig.encodeValue = encodeValue==undefined ? true : encodeValue;
+    },
+    encodeValue: function (encodeValue) {
+      defaultConfig.encodeValue = encodeValue==undefined ? true : encodeValue;
     },
     get: function (key) {
-      var value = decodeURIComponent(document.cookie.replace(new RegExp('(?:(?:^|.*;)\\s*' + encodeURIComponent(key).replace(/[\-\.\+\*]/g, '\\$&') + '\\s*\\=\\s*([^;]*).*$)|^.*$'), '$1')) || null;
+      var value = document.cookie.replace(new RegExp('(?:(?:^|.*;)\\s*' + encodeURIComponent(key).replace(/[\-\.\+\*]/g, '\\$&') + '\\s*\\=\\s*([^;]*).*$)|^.*$'), '$1');
+      value = (defaultConfig.encodeValue ? decodeURIComponent(value) : value) || null;
 
       if (value && value.substring(0, 1) === '{' && value.substring(value.length - 1, value.length) === '}') {
         try {
@@ -97,7 +103,7 @@
         }
       }
       document.cookie =
-          encodeURIComponent(key) + '=' + encodeURIComponent(value) +
+          encodeURIComponent(key) + '=' + defaultConfig.encodeValue ? encodeURIComponent(value) : value +
           _expires +
           (domain ? '; domain=' + domain : defaultConfig.domain) +
           (path ? '; path=' + path : defaultConfig.path) +


### PR DESCRIPTION
Fix #66 
As mentioned in #66, I think we should provide a way to let us determine whether we should encode cookie's value or not.
And we should compatible with the previous operations, so we should encode the cookie's value by default. This patch provides two ways to cancel encode operation:
1. set default config: `this.$cookies.config(expireTimes, path, domain, secure, sameSite, encodeValue)`;
2. use `this.$cookies.encodeValue(true/false)`

Signed-off-by: lifubang <lifubang@acmcoder.com>