### PR TITLE
Update type declaration file to match current version.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,8 +46,7 @@ interface CookiesConfig {
 }
 
 declare const _default : {
-  VueCookies: VueCookies;
   install: typeof install;
-};
+} & VueCookies;
 
 export default _default;


### PR DESCRIPTION
Type declaration file seemed to be outdated because there is no property named `VueCookies` exists inside default export. Instead, members in interface `VueCookies` lives in the default export. Therefore, I suppose to change the type declaration of default export object.