### PR TITLE
Augment vue instead of @vue/runtime-core

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -10,7 +10,7 @@ declare module "vue/types/vue" {
   }
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $cookies: VueCookies
   }


### PR DESCRIPTION
Fixes: https://github.com/cmp-cc/vue-cookies/issues/97

See documentation for augmenting global properties: https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties

Augmenting @vue/runtime-core breaks with vue-router@^4.4.1

Cf: https://github.com/vuejs/language-tools/issues/4793#issuecomment-2336471084